### PR TITLE
fixes and test exposing the bug

### DIFF
--- a/aes_test.go
+++ b/aes_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type Encryptor func(nr int, xk *uint32, dst, src *byte)
@@ -69,9 +71,9 @@ func TestMulti(t *testing.T) {
 			encryptBlocks8Asm(v.Rounds, &enc[0], &cipher[0], &plain[0])
 
 			for i := 0; i < c.Blocks; i++ {
-				if !bytes.Equal(cipher[16*i:16*i+16], v.Cipher) {
-					t.Errorf("error on block %d", i)
-				}
+				t.Run("block "+strconv.Itoa(i), func(t *testing.T) {
+					assert.Equal(t, v.Cipher, cipher[16*i:16*i+16])
+				})
 			}
 		})
 	}

--- a/aes_test.go
+++ b/aes_test.go
@@ -68,7 +68,7 @@ func TestMulti(t *testing.T) {
 			}
 
 			cipher := make([]byte, 16*c.Blocks)
-			encryptBlocks8Asm(v.Rounds, &enc[0], &cipher[0], &plain[0])
+			c.Encryptor(v.Rounds, &enc[0], &cipher[0], &plain[0])
 
 			for i := 0; i < c.Blocks; i++ {
 				t.Run("block "+strconv.Itoa(i), func(t *testing.T) {

--- a/aes_test.go
+++ b/aes_test.go
@@ -103,6 +103,7 @@ func EncryptorBenchmark(b *testing.B, f Encryptor, blocks int) {
 	plain := make([]byte, 16*blocks)
 	for i := 0; i < blocks; i++ {
 		copy(plain[16*i:], v.Plain)
+		plain[16*i] ^= byte(i)
 	}
 	cipher := make([]byte, 16*blocks)
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mmcloughlin/aesnix
+
+go 1.17

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/mmcloughlin/aesnix
 
 go 1.17
+
+require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
I applied test `TestMulti` to other cases. (It was only tested for encryptBlocks8Asm.)

```
$ go test
--- FAIL: TestMulti (0.00s)
    --- FAIL: TestMulti/10 (0.00s)
        aes_test.go:73: error on block 8
        aes_test.go:73: error on block 9
    --- FAIL: TestMulti/12 (0.00s)
        aes_test.go:73: error on block 8
        aes_test.go:73: error on block 9
        aes_test.go:73: error on block 10
        aes_test.go:73: error on block 11
    --- FAIL: TestMulti/14 (0.00s)
        aes_test.go:73: error on block 8
        aes_test.go:73: error on block 9
        aes_test.go:73: error on block 10
        aes_test.go:73: error on block 11
        aes_test.go:73: error on block 12
        aes_test.go:73: error on block 13
```

Multi processing of 10, 12 and 14 blocks seems to be broken.